### PR TITLE
Fix to mathjax url for github pages.

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/bootstrap-theme.css" />
     <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/lesson.css" />
 
-    <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <script>
       MathJax.Hub.Config({
       config: ["MMLorHTML.js"],


### PR DESCRIPTION
This is a **HUGE** changeset I know, but bear with me because it should fix the mathjax rendering :smirk_cat: 